### PR TITLE
Update _getTarget function

### DIFF
--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -455,11 +455,13 @@ Custom property | Description
         target = this.for;
       }
       //DOCUMENT_FRAGMENT_NODE
-      else if(parentNode.nodeType === 11) {
-          //at this point if we can't find the acual owner root
-          //we're probably not attached yet. Just set it to null
-          //and wait for 'this' to be attached and rerun this function
-          target = ownerRoot ? ownerRoot.host : null;
+      else if(parentNode) {
+          if(parentNode.nodeType === 11) {
+            //at this point if we can't find the acual owner root
+            //we're probably not attached yet. Just set it to null
+            //and wait for 'this' to be attached and rerun this function
+            target = ownerRoot ? ownerRoot.host : null;
+        }
       }
       else {
         target = parentNode;


### PR DESCRIPTION
This minor change allows to insert a tooltip and its target programmatically without the error of parentNode being null.
Originally, without the line 458, when making the conditional in line 459 ( if(parentNode.nodeType === 11) ) from the get go, if the px-tooltip was created using document.createElement(px-tooltip), then the code will run and it will break at line 459 because parentNode is null since its target hasn't been specified. If we first ask for the existence of the object parentNode, if this is null, this skips the condition altogether along with the error.

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

In the _getTarget function, I have added a condition (one line of code) to allow px-tooltip to be added programmatically, otherwise it breaks since the parentNode is null and the code asks for parentNode.nodeType, which gives an error

* ## A reference to a related issue (if applicable):
N/A
* ## @mentions of the person or team responsible for reviewing proposed changes:

Predix Dev team

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.

I have tested the fix on my current project. I work for GE in the GPS Controls Innovation Team
